### PR TITLE
Add hybrid squelch UI and manual threshold control feature

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
     "": {
       "name": "frontend",
       "version": "0.0.0",
+      "license": "GPL-3.0-only",
       "dependencies": {
         "@radix-ui/react-dialog": "^1.1.15",
         "@radix-ui/react-dropdown-menu": "^2.1.16",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -115,6 +115,8 @@ export default function App() {
       volume: 20,
       mute: false,
       squelch: false,
+      squelchAuto: true,
+      squelchLevel: -80,
       nr: false,
       nb: false,
       an: false,

--- a/src/components/audio/types.ts
+++ b/src/components/audio/types.ts
@@ -6,6 +6,8 @@ export type AudioUiSettings = {
   volume: number; // 0..100
   mute: boolean;
   squelch: boolean;
+  squelchAuto: boolean;     // true = auto (statistical), false = manual threshold
+  squelchLevel: number;     // manual threshold in dB (default: -80)
   nr: boolean;
   nb: boolean;
   an: boolean;

--- a/src/components/audio/useAudioClient.ts
+++ b/src/components/audio/useAudioClient.ts
@@ -129,7 +129,7 @@ export function useAudioClient({ receiverId, receiverSessionNonce, mode, centerH
   const lastWindowRef = useRef<string>('');
   const lastDemodRef = useRef<string>('');
   const lastSentMuteRef = useRef<boolean | null>(null);
-  const lastSentSquelchRef = useRef<boolean | null>(null);
+  const lastSentSquelchRef = useRef<string | null>(null);
   const lastSentAgcRef = useRef<string | null>(null);
   const receiverIdRef = useRef<string | null>(receiverId);
   const smeterOffsetDbRef = useRef<number>(0);
@@ -1003,10 +1003,14 @@ export function useAudioClient({ receiverId, receiverSessionNonce, mode, centerH
   useEffect(() => {
     if (!basicInfo) return;
     const enabled = settings.squelch;
-    if (lastSentSquelchRef.current === enabled) return;
-    if (!send({ cmd: 'squelch', enabled })) return;
-    lastSentSquelchRef.current = enabled;
-  }, [basicInfo, connectionNonce, send, settings.squelch]);
+    const level = (enabled && !settings.squelchAuto)
+      ? settings.squelchLevel - smeterOffsetDbRef.current
+      : null;
+    const key = `${enabled}:${settings.squelchAuto}:${settings.squelchLevel}`;
+    if (lastSentSquelchRef.current === key) return;
+    if (!send({ cmd: 'squelch', enabled, level })) return;
+    lastSentSquelchRef.current = key;
+  }, [basicInfo, connectionNonce, send, settings.squelch, settings.squelchAuto, settings.squelchLevel]);
 
   useEffect(() => {
     if (!basicInfo) return;

--- a/src/components/receiver/panels/AudioPanel.tsx
+++ b/src/components/receiver/panels/AudioPanel.tsx
@@ -90,6 +90,33 @@ export function AudioPanel({
           />
         </div>
 
+        {settings.squelch && (
+          <div className="ml-2 space-y-2 border-l-2 border-primary/20 pl-3">
+            <ToggleSmall
+              label="Auto"
+              help="Uses automatic noise detection algorithm to open/close squelch."
+              checked={settings.squelchAuto}
+              onCheckedChange={(checked) =>
+                onChange((prev) => ({ ...prev, squelchAuto: checked }))
+              }
+            />
+            {!settings.squelchAuto && (
+              <div className="space-y-1">
+                <Label className="text-xs">Level ({settings.squelchLevel} dB)</Label>
+                <Slider
+                  value={[settings.squelchLevel]}
+                  min={-140}
+                  max={0}
+                  step={1}
+                  onValueChange={([v]) =>
+                    onChange((prev) => ({ ...prev, squelchLevel: v }))
+                  }
+                />
+              </div>
+            )}
+          </div>
+        )}
+
         <div className="grid grid-cols-3 gap-3">
           <ToggleSmall
             label="NR"


### PR DESCRIPTION
This pull request enhances the squelch functionality in the audio settings by introducing automatic and manual squelch modes, along with a configurable squelch threshold. These changes improve user control and flexibility over audio filtering, and update both the UI and backend logic to support the new features.

**Audio squelch feature enhancements:**

* Added `squelchAuto` and `squelchLevel` properties to the `AudioUiSettings` type to support automatic (statistical) and manual squelch modes, with a user-defined threshold in dB.
* Updated the state initialization in `App` to include `squelchAuto` (default: true) and `squelchLevel` (default: -80).

**UI improvements:**

* Modified `AudioPanel` to display toggles for squelch auto/manual mode and a slider for manual squelch level when squelch is enabled, allowing users to easily adjust squelch settings.

**Backend logic updates:**

* Enhanced the squelch effect in `useAudioClient` to send both the squelch mode and level to the backend, and track changes using a composite key to prevent redundant updates.
* Changed the reference tracking for squelch state in `useAudioClient` from a boolean to a string key to accommodate the new squelch properties.